### PR TITLE
Add static marketing site for Project Airos

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ Check [docs/](docs/) for early developer documentation.
 
 ---
 
+## 🌐 Website
+
+The marketing site for Project Airos lives in [`site/`](site/). It is a static HTML/CSS experience that highlights the mission,
+technology, and flagship applications inspired by Meta's Project Aria research.
+
+### Local preview
+
+1. `cd site`
+2. Start a lightweight web server: `python -m http.server 8000`
+3. Open `http://localhost:8000/index.html` in your browser and iterate on the content.
+
+The site uses shared assets and relative links, so always run it from the `site/` directory or through a static hosting service.
+
+### Deployment
+
+Read [docs/deployment.md](docs/deployment.md) for recommended workflows to publish the latest site to GitHub Pages, Netlify, or
+other static hosts as content evolves.
+
+---
+
 ## 🌐 Roadmap
 
 - [ ] Voice-first client (ASR + TTS + chat loop).  

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,47 @@
+# Project Airos Website Deployment Guide
+
+The Project Airos site lives in the [`site/`](../site) directory. It is a static bundle (HTML, CSS, and a small JavaScript
+snippet) that can be hosted on any CDN or static web platform.
+
+## 1. Prepare the build
+
+Because the site is already static, the "build" step is simply ensuring all files under `site/` are up to date.
+
+```bash
+cd site
+python -m http.server 8000  # optional sanity check locally
+```
+
+Commit and push your changes once you are satisfied with the preview.
+
+## 2. Deploy to GitHub Pages
+
+1. Create a branch and push the updated site content.
+2. In the GitHub repository, enable **GitHub Pages** with the `main` branch and `/site` folder.
+3. GitHub will automatically serve the content at `https://<org>.github.io/<repo>/`.
+4. When you merge new updates into `main`, Pages will redeploy.
+
+> Tip: if you prefer a dedicated branch such as `gh-pages`, add a GitHub Action that copies the `site/` directory into that
+> branch on every push.
+
+## 3. Deploy to Netlify or Vercel
+
+1. Connect the repository to your hosting provider.
+2. Configure the project to serve from the `site` directory with no build command (or `cp -r site/* public/` if a step is
+   required).
+3. Every push to the configured branch will trigger a redeploy.
+
+## 4. Manual hosting / S3 + CloudFront
+
+1. Zip the contents of `site/` and upload them to an S3 bucket configured for static site hosting.
+2. Invalidate the CDN cache (CloudFront or similar) after uploading new versions.
+3. Automate the upload with a script if you frequently update content.
+
+## 5. Content workflow best practices
+
+- **Preview first**: use `python -m http.server` or a Live Server plugin to view updates locally.
+- **Branch per update**: collaborate via pull requests to review copy, visuals, and layout changes.
+- **Track assets**: store future imagery under `site/assets/` and optimize (WebP/AVIF) before commit.
+- **Document releases**: summarize major content updates in the blog section to keep visitors informed.
+
+With these steps you can iterate quickly on the Project Airos site and publish changes to production safely.

--- a/site/about.html
+++ b/site/about.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>About Project Airos</title>
+    <meta
+      name="description"
+      content="Learn how Project Airos empowers sovereign, privacy-first AI agents inspired by Meta's Project Aria and community-led innovation."
+    />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="brand" href="index.html">
+          <span class="brand-logo" aria-hidden="true"></span>
+          <span>Project Airos</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+        <div class="nav-links" id="primary-navigation">
+          <a href="about.html" aria-current="page">About</a>
+          <a href="tech.html">Technology</a>
+          <a href="applications.html">Applications</a>
+          <a href="docs.html">Docs</a>
+          <a href="community.html">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="page-hero">
+        <div class="badge">Our story</div>
+        <h1>Why Project Airos exists</h1>
+        <p>
+          We believe AI should be sovereign: user-controlled, transparent, and available on devices people already own. Project
+          Airos blends frontier research like Meta’s Project Aria with open-source values and community co-creation.
+        </p>
+      </section>
+
+      <section class="content-section">
+        <article class="highlight-box">
+          <h2>The challenge</h2>
+          <p>
+            AI ecosystems today are cloud-only, gated by proprietary APIs, and designed to capture data. This model leaves
+            individuals, educators, and smaller labs without privacy, agency, or affordability.
+          </p>
+          <div class="list">
+            <div><strong>Vendor lock-in:</strong> Closed platforms shape the rules and pricing.</div>
+            <div><strong>Data risk:</strong> Personal context and sensor feeds must leave the device to become useful.</div>
+            <div><strong>Equity gap:</strong> Emerging markets and public institutions can’t rely on always-on connectivity.</div>
+          </div>
+        </article>
+        <article class="highlight-box">
+          <h2>Our response</h2>
+          <p>
+            Airos is a modular Agent OS that runs locally or at the edge. It empowers builders to orchestrate voice, vision, and
+            context-aware intelligence with open tooling.
+          </p>
+          <div class="list">
+            <div><strong>Local-first:</strong> Keep computation and memory on trusted hardware whenever possible.</div>
+            <div><strong>Portable memory:</strong> Combine short-term and long-term context under user ownership.</div>
+            <div><strong>Community-driven:</strong> Build in the open, inspired by pioneers like Project Aria while extending what’s possible.</div>
+          </div>
+        </article>
+      </section>
+
+      <section class="content-section">
+        <div>
+          <h2>What makes Airos different</h2>
+          <p>
+            Meta’s Project Aria showed how rich sensor suites can power advanced AR experiences, yet the stack remained closed.
+            Airos takes the inspiration and opens the blueprint: from the voice loop to the memory fabric, every layer is built to
+            be forked, audited, and remixed.
+          </p>
+        </div>
+        <table class="table">
+          <thead>
+            <tr>
+              <th scope="col">Dimension</th>
+              <th scope="col">Closed status quo</th>
+              <th scope="col">Project Airos</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Deployment</strong></td>
+              <td>Cloud-dependent, single provider</td>
+              <td>On-device, edge, or hybrid — user decides</td>
+            </tr>
+            <tr>
+              <td><strong>Transparency</strong></td>
+              <td>Opaque models and pipelines</td>
+              <td>Open-source, auditable components</td>
+            </tr>
+            <tr>
+              <td><strong>Memory</strong></td>
+              <td>Data locked in proprietary silos</td>
+              <td>Portable memory fabric under user control</td>
+            </tr>
+            <tr>
+              <td><strong>Community</strong></td>
+              <td>Limited access to research artifacts</td>
+              <td>Open roadmap, shared demos, collaborative pilots</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="content-section">
+        <div>
+          <h2>Roadmap milestones</h2>
+          <p>The core team and community contributors focus on three parallel tracks of development.</p>
+        </div>
+        <div class="timeline">
+          <div class="timeline-item">
+            <h3>Voice-first interfaces</h3>
+            <p>Voice UX toolkits, wake word inference, and multimodal prompt loops for daily wearables.</p>
+          </div>
+          <div class="timeline-item">
+            <h3>Memory + personalization</h3>
+            <p>Portable vector stores and secure sync protocols for individuals, families, and classrooms.</p>
+          </div>
+          <div class="timeline-item">
+            <h3>Edge deployment program</h3>
+            <p>Blueprints for running Airos in labs, schools, and community spaces with commodity hardware.</p>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-content">
+        <div>
+          <strong>Project Airos</strong>
+          <p class="quote">Sovereign AI crafted by and for the communities who deploy it.</p>
+        </div>
+        <div class="footer-links">
+          <a href="docs.html">Docs</a>
+          <a href="community.html">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+        </div>
+        <small>© <span id="year"></span> Project Airos. MIT Licensed.</small>
+      </div>
+    </footer>
+    <script src="assets/app.js" defer></script>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/site/applications.html
+++ b/site/applications.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Project Airos Applications</title>
+    <meta
+      name="description"
+      content="Discover flagship applications powered by Project Airos, from smart glasses agents to privacy-first education tutors."
+    />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="brand" href="index.html">
+          <span class="brand-logo" aria-hidden="true"></span>
+          <span>Project Airos</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+        <div class="nav-links" id="primary-navigation">
+          <a href="about.html">About</a>
+          <a href="tech.html">Technology</a>
+          <a href="applications.html" aria-current="page">Applications</a>
+          <a href="docs.html">Docs</a>
+          <a href="community.html">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="page-hero">
+        <div class="badge">Use cases</div>
+        <h1>Flagship demos that prove the mission</h1>
+        <p>
+          The Project Airos stack unlocks immersive wearables and equitable learning experiences. Explore how we adapt research
+          like Meta’s Project Aria into open deployments.
+        </p>
+      </section>
+
+      <section class="content-section" id="smart-glasses">
+        <article class="highlight-box">
+          <h2>Smart Glasses Agent</h2>
+          <p class="lead">
+            Marrying Project Aria’s sensor fidelity with sovereign AI. Always-available assistance that respects your privacy.
+          </p>
+          <div class="split">
+            <div class="list">
+              <div><strong>Voice-first loop:</strong> Wake words, ASR, and conversational AI running locally.</div>
+              <div><strong>Vision Q&A:</strong> Capture photos, ask contextual questions, and receive on-device insights.</div>
+              <div><strong>Safety by design:</strong> Physical shutters, LED indicators, and granular consent for memory.</div>
+            </div>
+            <div class="feature-visual">
+              <span>Wearable SDK with sensor simulators</span>
+              <span>Offline inference packs</span>
+              <span>Edge sync with trusted hubs</span>
+              <span>Open hardware reference design</span>
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section class="content-section" id="education">
+        <article class="highlight-box">
+          <h2>AI for Education Tutor</h2>
+          <p class="lead">
+            Personalized, Socratic guidance for learners — delivered on affordable devices without exposing student data.
+          </p>
+          <div class="split">
+            <div class="list">
+              <div><strong>Adaptive dialogue:</strong> Track misconceptions and progress in local vector memory.</div>
+              <div><strong>Hybrid deployment:</strong> Run on classroom edge servers or offline laptops.</div>
+              <div><strong>Inclusive access:</strong> Multilingual ASR/TTS pipelines and low-bandwidth optimization.</div>
+            </div>
+            <div class="feature-visual">
+              <span>Curriculum-aligned prompt packs</span>
+              <span>Teacher dashboards with opt-in sharing</span>
+              <span>Community translation contributions</span>
+              <span>Guardrails for safe tutoring</span>
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section class="content-section">
+        <div class="highlight-box">
+          <h2>More frontiers</h2>
+          <p>
+            Airos is designed for any domain where sovereignty, privacy, and multimodal intelligence matter.
+          </p>
+          <div class="grid">
+            <div class="card">
+              <h3>Healthcare assistive devices</h3>
+              <p>Securely assist clinicians and caregivers with on-premise inference and auditable logs.</p>
+            </div>
+            <div class="card">
+              <h3>Industrial safety copilots</h3>
+              <p>Overlay guidance in AR headsets with offline failover and ruggedized hardware support.</p>
+            </div>
+            <div class="card">
+              <h3>Creative studios</h3>
+              <p>Blend voice, gesture, and spatial computing for immersive storytelling and design sprints.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-content">
+        <div>
+          <strong>Project Airos</strong>
+          <p class="quote">From wearables to classrooms, Airos brings open, sovereign agents to real-world challenges.</p>
+        </div>
+        <div class="footer-links">
+          <a href="docs.html">Docs</a>
+          <a href="community.html">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+        </div>
+        <small>© <span id="year"></span> Project Airos. MIT Licensed.</small>
+      </div>
+    </footer>
+    <script src="assets/app.js" defer></script>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1,0 +1,10 @@
+const toggle = document.querySelector('.nav-toggle');
+const navLinks = document.querySelector('.nav-links');
+
+if (toggle && navLinks) {
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!expanded));
+    navLinks.classList.toggle('open');
+  });
+}

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1,0 +1,498 @@
+:root {
+  --color-background: #050b14;
+  --color-surface: rgba(15, 25, 40, 0.85);
+  --color-primary: #6cf0ff;
+  --color-secondary: #7b61ff;
+  --color-accent: #39d98a;
+  --color-text: #f6f8ff;
+  --color-muted: rgba(246, 248, 255, 0.7);
+  --max-width: 1100px;
+  --border-radius: 20px;
+  --shadow-elevated: 0 25px 60px rgba(12, 21, 37, 0.45);
+  --gradient-hero: radial-gradient(circle at 20% 20%, rgba(108, 240, 255, 0.3), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(123, 97, 255, 0.35), transparent 60%),
+    linear-gradient(180deg, #050b14 0%, #0b1323 50%, #0f1a2d 100%);
+  --gradient-card: linear-gradient(150deg, rgba(123, 97, 255, 0.24), rgba(57, 217, 138, 0.12));
+  --gradient-chip: linear-gradient(120deg, rgba(108, 240, 255, 0.2), rgba(123, 97, 255, 0.2));
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--gradient-hero);
+  color: var(--color-text);
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-primary);
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  backdrop-filter: blur(24px);
+  background: rgba(5, 11, 20, 0.85);
+  border-bottom: 1px solid rgba(108, 240, 255, 0.1);
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  max-width: calc(var(--max-width) + 4rem);
+}
+
+.navbar .brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.navbar .brand-logo {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: linear-gradient(140deg, var(--color-secondary), var(--color-primary));
+  box-shadow: var(--shadow-elevated);
+}
+
+.nav-links {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.nav-links a {
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+  background: rgba(108, 240, 255, 0.14);
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: 1px solid rgba(108, 240, 255, 0.3);
+  color: var(--color-text);
+  padding: 0.35rem 0.6rem;
+  border-radius: 8px;
+}
+
+.hero {
+  margin: 0 auto;
+  max-width: calc(var(--max-width) + 4rem);
+  padding: 6rem 1.5rem 4rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero-text h1 {
+  font-size: clamp(2.5rem, 4vw + 1rem, 4.5rem);
+  margin: 0 0 1rem;
+  line-height: 1.1;
+}
+
+.hero-text p {
+  margin: 0 0 1.75rem;
+  font-size: 1.12rem;
+  color: var(--color-muted);
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  color: #050b14;
+  padding: 0.8rem 1.4rem;
+  font-weight: 600;
+  border-radius: 999px;
+  box-shadow: 0 15px 35px rgba(108, 240, 255, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button.secondary {
+  background: transparent;
+  color: var(--color-primary);
+  border: 1px solid rgba(108, 240, 255, 0.45);
+  box-shadow: none;
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 40px rgba(108, 240, 255, 0.35);
+}
+
+.button.secondary:hover,
+.button.secondary:focus {
+  box-shadow: 0 12px 35px rgba(123, 97, 255, 0.25);
+}
+
+.hero-visual {
+  position: relative;
+  background: linear-gradient(140deg, rgba(123, 97, 255, 0.4), rgba(57, 217, 138, 0.2));
+  border-radius: 32px;
+  padding: 2.5rem;
+  overflow: hidden;
+  box-shadow: var(--shadow-elevated);
+  min-height: 340px;
+}
+
+.hero-visual::after {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: 28px;
+  border: 1px solid rgba(108, 240, 255, 0.35);
+  pointer-events: none;
+}
+
+.hero-orbital {
+  position: absolute;
+  inset: -40px 20% auto auto;
+  width: 180px;
+  height: 180px;
+  background: radial-gradient(circle, rgba(108, 240, 255, 0.5), transparent 70%);
+  border-radius: 50%;
+  filter: blur(0px);
+}
+
+.section {
+  margin: 0 auto;
+  max-width: calc(var(--max-width) + 4rem);
+  padding: 0 1.5rem 4rem;
+}
+
+.section h2 {
+  font-size: clamp(2rem, 2vw + 1rem, 3rem);
+  margin-bottom: 1rem;
+}
+
+.section p.lead {
+  color: var(--color-muted);
+  max-width: 720px;
+  font-size: 1.05rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.75rem;
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: var(--border-radius);
+  padding: 1.8rem;
+  border: 1px solid rgba(108, 240, 255, 0.12);
+  box-shadow: var(--shadow-elevated);
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--gradient-card);
+  opacity: 0.65;
+  z-index: 0;
+}
+
+.card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.3rem;
+}
+
+.card p {
+  color: var(--color-muted);
+  line-height: 1.55;
+}
+
+.chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1.25rem;
+}
+
+.chip {
+  padding: 0.35rem 0.8rem;
+  background: var(--gradient-chip);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  letter-spacing: 0.03em;
+}
+
+.feature-visual {
+  border-radius: 18px;
+  border: 1px solid rgba(108, 240, 255, 0.25);
+  padding: 1.5rem;
+  background: linear-gradient(140deg, rgba(123, 97, 255, 0.2), rgba(108, 240, 255, 0.18));
+  display: grid;
+  gap: 0.75rem;
+}
+
+.feature-visual span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.feature-visual span::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--color-accent);
+}
+
+.split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.timeline {
+  border-left: 2px solid rgba(108, 240, 255, 0.25);
+  margin-top: 1.5rem;
+  padding-left: 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline-item {
+  position: relative;
+}
+
+.timeline-item::before {
+  content: "";
+  position: absolute;
+  top: 0.3rem;
+  left: -1.71rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid var(--color-background);
+  background: var(--color-primary);
+}
+
+footer {
+  margin-top: 4rem;
+  padding: 3rem 1.5rem;
+  background: rgba(5, 11, 20, 0.9);
+  border-top: 1px solid rgba(108, 240, 255, 0.12);
+}
+
+footer .footer-content {
+  margin: 0 auto;
+  max-width: calc(var(--max-width) + 4rem);
+  display: grid;
+  gap: 1.5rem;
+}
+
+footer .footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  color: var(--color-muted);
+}
+
+@media (max-width: 820px) {
+  .nav-links {
+    position: absolute;
+    inset: 64px 1.5rem auto;
+    flex-direction: column;
+    background: rgba(5, 11, 20, 0.95);
+    border: 1px solid rgba(108, 240, 255, 0.12);
+    padding: 1.5rem;
+    border-radius: 16px;
+    box-shadow: var(--shadow-elevated);
+    display: none;
+  }
+
+  .nav-links.open {
+    display: flex;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  header {
+    position: sticky;
+  }
+}
+
+main {
+  margin-top: 2rem;
+}
+
+.page-hero {
+  margin: 0 auto;
+  max-width: calc(var(--max-width) + 4rem);
+  padding: 5rem 1.5rem 2.5rem;
+}
+
+.page-hero h1 {
+  font-size: clamp(2.4rem, 3vw + 1rem, 3.6rem);
+  margin-bottom: 0.5rem;
+}
+
+.page-hero p {
+  max-width: 720px;
+  color: var(--color-muted);
+}
+
+.content-section {
+  margin: 0 auto 4rem;
+  max-width: calc(var(--max-width) + 4rem);
+  padding: 0 1.5rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.content-section h2 {
+  margin-bottom: 0.5rem;
+}
+
+.content-section p {
+  color: var(--color-muted);
+  line-height: 1.6;
+}
+
+.highlight-box {
+  background: var(--color-surface);
+  border-radius: var(--border-radius);
+  padding: 2rem;
+  border: 1px solid rgba(108, 240, 255, 0.15);
+  box-shadow: var(--shadow-elevated);
+}
+
+.list {
+  display: grid;
+  gap: 0.75rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.list strong {
+  color: var(--color-text);
+}
+
+.quote {
+  font-style: italic;
+  color: var(--color-muted);
+  border-left: 3px solid rgba(108, 240, 255, 0.4);
+  padding-left: 1.2rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--color-surface);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+}
+
+.table th,
+.table td {
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(108, 240, 255, 0.08);
+  text-align: left;
+}
+
+.table th {
+  color: var(--color-muted);
+  font-weight: 600;
+  background: rgba(108, 240, 255, 0.08);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(123, 97, 255, 0.2);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.contact-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-card a {
+  color: var(--color-primary);
+}
+
+.blog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.blog-card {
+  padding: 1.8rem;
+  border-radius: var(--border-radius);
+  background: var(--color-surface);
+  border: 1px solid rgba(108, 240, 255, 0.14);
+  box-shadow: var(--shadow-elevated);
+  display: grid;
+  gap: 1rem;
+}
+
+.blog-card span {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+footer small {
+  color: rgba(246, 248, 255, 0.5);
+}
+

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Project Airos Blog</title>
+    <meta
+      name="description"
+      content="News, release notes, and stories from the Project Airos community."
+    />
+    <link rel="stylesheet" href="../assets/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="brand" href="../index.html">
+          <span class="brand-logo" aria-hidden="true"></span>
+          <span>Project Airos</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+        <div class="nav-links" id="primary-navigation">
+          <a href="../about.html">About</a>
+          <a href="../tech.html">Technology</a>
+          <a href="../applications.html">Applications</a>
+          <a href="../docs.html">Docs</a>
+          <a href="../community.html">Community</a>
+          <a href="index.html" aria-current="page">Blog</a>
+          <a href="../contact.html">Contact</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="page-hero">
+        <div class="badge">Blog</div>
+        <h1>Stories from the sovereign AI frontier</h1>
+        <p>
+          Release notes, tutorials, and case studies from the Project Airos community. Subscribe for launch updates and deep
+          dives.
+        </p>
+      </section>
+
+      <section class="content-section">
+        <div class="blog-grid">
+          <article class="blog-card">
+            <span>Coming soon</span>
+            <h3>Launch roadmap and community calls</h3>
+            <p>
+              We’re preparing our first long-form post with details on the MVP stack, partner pilots, and how to contribute.
+              Check back soon!
+            </p>
+          </article>
+          <article class="blog-card">
+            <span>Coming soon</span>
+            <h3>Field notes: adapting Project Aria research</h3>
+            <p>
+              A behind-the-scenes look at how Airos takes inspiration from Meta’s Project Aria and turns it into community-owned
+              tooling.
+            </p>
+          </article>
+          <article class="blog-card">
+            <span>Coming soon</span>
+            <h3>AI for Education pilot report</h3>
+            <p>
+              Stories from educators deploying Airos tutors in bandwidth-constrained environments with full data sovereignty.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-content">
+        <div>
+          <strong>Project Airos</strong>
+          <p class="quote">Follow the blog for release notes, partner spotlights, and developer deep dives.</p>
+        </div>
+        <div class="footer-links">
+          <a href="../docs.html">Docs</a>
+          <a href="../community.html">Community</a>
+          <a href="index.html">Blog</a>
+          <a href="../contact.html">Contact</a>
+        </div>
+        <small>© <span id="year"></span> Project Airos. MIT Licensed.</small>
+      </div>
+    </footer>
+    <script src="../assets/app.js" defer></script>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/site/community.html
+++ b/site/community.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Project Airos Community</title>
+    <meta
+      name="description"
+      content="Discover how to contribute to Project Airos through code, research, storytelling, and real-world deployments."
+    />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="brand" href="index.html">
+          <span class="brand-logo" aria-hidden="true"></span>
+          <span>Project Airos</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+        <div class="nav-links" id="primary-navigation">
+          <a href="about.html">About</a>
+          <a href="tech.html">Technology</a>
+          <a href="applications.html">Applications</a>
+          <a href="docs.html">Docs</a>
+          <a href="community.html" aria-current="page">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="page-hero">
+        <div class="badge">Community</div>
+        <h1>Build Airos together</h1>
+        <p>
+          Project Airos thrives on shared experimentation. Join our contributors, researchers, and educators to shape the next
+          generation of sovereign AI.
+        </p>
+      </section>
+
+      <section class="content-section">
+        <div class="grid">
+          <article class="card">
+            <h3>Contribute code</h3>
+            <p>
+              Dive into orchestrator modules, ASR/TTS adapters, and reference clients. Issues are triaged weekly with clear
+              priorities.
+            </p>
+            <div class="chip-list">
+              <span class="chip">Good first issues</span>
+              <span class="chip">RFCs</span>
+              <span class="chip">Pairing sessions</span>
+            </div>
+          </article>
+          <article class="card">
+            <h3>Share research</h3>
+            <p>
+              Collaborate on evaluation benchmarks, privacy-preserving techniques, and multimodal UX studies for wearables.
+            </p>
+            <div class="chip-list">
+              <span class="chip">Academic collabs</span>
+              <span class="chip">Sensor datasets</span>
+              <span class="chip">Field notes</span>
+            </div>
+          </article>
+          <article class="card">
+            <h3>Lead deployments</h3>
+            <p>
+              Pilot Airos in schools, makerspaces, and research labs. Document your learnings for the global community.
+            </p>
+            <div class="chip-list">
+              <span class="chip">Edge ops</span>
+              <span class="chip">Case studies</span>
+              <span class="chip">Workshops</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="content-section">
+        <article class="highlight-box">
+          <h2>Ways to connect</h2>
+          <div class="list">
+            <div><strong>GitHub:</strong> Track issues, propose features, and submit pull requests.</div>
+            <div><strong>Community calls:</strong> Monthly sync covering roadmap updates and lightning talks.</div>
+            <div><strong>Storytelling:</strong> Contribute blog posts, tutorials, and field reports about Airos deployments.</div>
+            <div><strong>Events:</strong> Meetups at open-source conferences and XR gatherings.</div>
+          </div>
+        </article>
+      </section>
+
+      <section class="content-section">
+        <div class="highlight-box">
+          <h2>Code of Conduct</h2>
+          <p>
+            We follow a zero-tolerance approach to harassment and discrimination. Please review the Project Airos Code of
+            Conduct before engaging in any channel.
+          </p>
+          <a class="button secondary" href="https://github.com/project-airos/project-airos/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noreferrer"
+            >Read the Code of Conduct</a
+          >
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-content">
+        <div>
+          <strong>Project Airos</strong>
+          <p class="quote">Community-powered innovation keeps Airos open, private, and impactful.</p>
+        </div>
+        <div class="footer-links">
+          <a href="docs.html">Docs</a>
+          <a href="community.html">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+        </div>
+        <small>© <span id="year"></span> Project Airos. MIT Licensed.</small>
+      </div>
+    </footer>
+    <script src="assets/app.js" defer></script>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/site/contact.html
+++ b/site/contact.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Contact Project Airos</title>
+    <meta
+      name="description"
+      content="Reach the Project Airos team for collaborations, press, and partnership opportunities."
+    />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="brand" href="index.html">
+          <span class="brand-logo" aria-hidden="true"></span>
+          <span>Project Airos</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+        <div class="nav-links" id="primary-navigation">
+          <a href="about.html">About</a>
+          <a href="tech.html">Technology</a>
+          <a href="applications.html">Applications</a>
+          <a href="docs.html">Docs</a>
+          <a href="community.html">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html" aria-current="page">Contact</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="page-hero">
+        <div class="badge">Contact</div>
+        <h1>Let’s collaborate</h1>
+        <p>
+          Whether you’re adapting Project Airos for wearables, piloting AI tutors, or covering sovereign AI, we’d love to hear
+          from you.
+        </p>
+      </section>
+
+      <section class="content-section">
+        <div class="split">
+          <div class="contact-card">
+            <h2>Reach the team</h2>
+            <p>Email us directly and we’ll route your request to the right contributors.</p>
+            <a href="mailto:info@projectairos.org" class="button">info@projectairos.org</a>
+            <p class="quote">Expect a response within 2–3 working days.</p>
+          </div>
+          <div class="highlight-box">
+            <h2>Media & partnerships</h2>
+            <p>
+              Interested in covering Airos, exploring research collaborations, or deploying pilots? Share a brief overview and
+              we’ll set up a call.
+            </p>
+            <ul class="list">
+              <li>Press inquiries and speaking engagements</li>
+              <li>University and lab collaborations</li>
+              <li>Hardware and sensor partnerships</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="content-section">
+        <div class="highlight-box">
+          <h2>Stay in the loop</h2>
+          <p>
+            Subscribe to upcoming release notes and community calls. Newsletter sign-up launches soon — follow the blog in the
+            meantime for updates.
+          </p>
+          <a class="button secondary" href="blog/index.html">View blog</a>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-content">
+        <div>
+          <strong>Project Airos</strong>
+          <p class="quote">Let’s build open, privacy-first AI experiences together.</p>
+        </div>
+        <div class="footer-links">
+          <a href="docs.html">Docs</a>
+          <a href="community.html">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+        </div>
+        <small>© <span id="year"></span> Project Airos. MIT Licensed.</small>
+      </div>
+    </footer>
+    <script src="assets/app.js" defer></script>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/site/docs.html
+++ b/site/docs.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Project Airos Docs</title>
+    <meta
+      name="description"
+      content="Quickstart guides and reference material for running Project Airos locally, on the edge, or in the cloud."
+    />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="brand" href="index.html">
+          <span class="brand-logo" aria-hidden="true"></span>
+          <span>Project Airos</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+        <div class="nav-links" id="primary-navigation">
+          <a href="about.html">About</a>
+          <a href="tech.html">Technology</a>
+          <a href="applications.html">Applications</a>
+          <a href="docs.html" aria-current="page">Docs</a>
+          <a href="community.html">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="page-hero">
+        <div class="badge">Documentation</div>
+        <h1>Build with Airos</h1>
+        <p>
+          High-level guides and references will grow into a full documentation portal. Start here for prototypes and pilot
+          deployments.
+        </p>
+      </section>
+
+      <section class="content-section">
+        <article class="highlight-box">
+          <h2>Quickstart</h2>
+          <div class="list">
+            <div><strong>1.</strong> Clone the repository and explore the sample agents.</div>
+            <div><strong>2.</strong> Provision dependencies: Docker, Node.js, Python, and your preferred GPU runtime.</div>
+            <div><strong>3.</strong> Configure credentials for OpenAI, Anthropic, Qwen, or on-prem models.</div>
+            <div><strong>4.</strong> Launch the voice-first demo client and experiment with local inference.</div>
+          </div>
+        </article>
+      </section>
+
+      <section class="content-section">
+        <div class="grid">
+          <article class="card">
+            <h3>Local development</h3>
+            <p>Use Docker Compose recipes to bring up the orchestrator, ASR, TTS, and UI services with hot reload.</p>
+            <div class="chip-list">
+              <span class="chip">Docker</span>
+              <span class="chip">Hot reload</span>
+              <span class="chip">Live transcripts</span>
+            </div>
+          </article>
+          <article class="card">
+            <h3>Edge deployment</h3>
+            <p>Deploy to edge clusters with Kubernetes or Nomad and leverage GPU pools for heavy workloads.</p>
+            <div class="chip-list">
+              <span class="chip">K8s</span>
+              <span class="chip">Nomad</span>
+              <span class="chip">Observability</span>
+            </div>
+          </article>
+          <article class="card">
+            <h3>Extending modules</h3>
+            <p>Add new ASR, TTS, or LLM backends by implementing the adapter contract and registering capabilities.</p>
+            <div class="chip-list">
+              <span class="chip">Adapter SDK</span>
+              <span class="chip">Capability graph</span>
+              <span class="chip">Testing harness</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="content-section">
+        <div class="highlight-box">
+          <h2>Docs roadmap</h2>
+          <p>Upcoming additions to the documentation hub.</p>
+          <ul class="list">
+            <li>Deep dives into ASR/TTS optimization and streaming protocols.</li>
+            <li>Guides for memory synchronization across devices.</li>
+            <li>Sample curriculum for the AI tutor deployment.</li>
+            <li>API reference for the agent orchestration layer.</li>
+          </ul>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-content">
+        <div>
+          <strong>Project Airos</strong>
+          <p class="quote">Documentation evolves with the community — contribute guides, samples, and tutorials.</p>
+        </div>
+        <div class="footer-links">
+          <a href="docs.html">Docs</a>
+          <a href="community.html">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+        </div>
+        <small>© <span id="year"></span> Project Airos. MIT Licensed.</small>
+      </div>
+    </footer>
+    <script src="assets/app.js" defer></script>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Project Airos — Sovereign AI, in your hands</title>
+    <meta
+      name="description"
+      content="Project Airos is an open-source AI Agent OS for privacy-first, local and edge intelligence across phones, PCs, and smart glasses."
+    />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="brand" href="index.html">
+          <span class="brand-logo" aria-hidden="true"></span>
+          <span>Project Airos</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+        <div class="nav-links" id="primary-navigation">
+          <a href="about.html">About</a>
+          <a href="tech.html">Technology</a>
+          <a href="applications.html">Applications</a>
+          <a href="docs.html">Docs</a>
+          <a href="community.html">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="hero">
+        <div class="hero-text">
+          <div class="badge">Open-source agent OS</div>
+          <h1>Sovereign AI, in your hands.</h1>
+          <p>
+            Project Airos is the open-source Agent OS for on-device and edge intelligence. Inspired by Meta's Project Aria and
+            other frontier research, we deliver privacy-first AI agents that run wherever people live, work, and create.
+          </p>
+          <div class="hero-actions">
+            <a class="button" href="docs.html">Get started</a>
+            <a class="button secondary" href="https://github.com/project-airos" target="_blank" rel="noreferrer">Explore GitHub</a>
+          </div>
+        </div>
+        <div class="hero-visual" aria-hidden="true">
+          <div class="hero-orbital"></div>
+          <div class="feature-visual">
+            <span>Edge-ready orchestration</span>
+            <span>Privacy-first wearable UX</span>
+            <span>Voice + vision multimodal loop</span>
+            <span>Portable memory across devices</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Why Airos now?</h2>
+        <p class="lead">
+          AI is becoming the operating layer for daily life, yet today’s solutions are cloud-bound and vendor-controlled.
+          Project Airos puts sovereign intelligence in the hands of builders, researchers, and communities.
+        </p>
+        <div class="grid">
+          <article class="card">
+            <h3>Local-first performance</h3>
+            <p>
+              Run ASR, TTS, and LLM inference on-device or at the edge. Use the cloud when you choose, not when you are forced.
+            </p>
+            <div class="chip-list">
+              <span class="chip">Phones</span>
+              <span class="chip">PCs</span>
+              <span class="chip">Wearables</span>
+            </div>
+          </article>
+          <article class="card">
+            <h3>Transparent + auditable</h3>
+            <p>
+              Airos is open-source from core orchestration to UX. Inspect, customize, and extend everything you deploy.
+            </p>
+            <div class="chip-list">
+              <span class="chip">MCP</span>
+              <span class="chip">Rust + Python</span>
+              <span class="chip">OSS LLMs</span>
+            </div>
+          </article>
+          <article class="card">
+            <h3>Inspired by pioneers</h3>
+            <p>
+              Learn from Meta’s Project Aria hardware research without the walled garden. Airos embraces open communities and
+              sovereign data.
+            </p>
+            <div class="chip-list">
+              <span class="chip">Project Aria</span>
+              <span class="chip">Project Astra</span>
+              <span class="chip">Open XR</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="split">
+          <div>
+            <h2>Composable stack for multimodal agents</h2>
+            <p class="lead">
+              Build voice-first, vision-aware agents with modular components. Choose the best ASR, TTS, LLM, and memory providers
+              for your deployment.
+            </p>
+            <div class="chip-list">
+              <span class="chip">Whisper · FunASR</span>
+              <span class="chip">PrimeSpeech · Piper</span>
+              <span class="chip">vLLM · Qwen · Claude</span>
+              <span class="chip">Local vector DB</span>
+            </div>
+          </div>
+          <div class="feature-visual">
+            <span>Edge orchestrator with MCP</span>
+            <span>Modular ASR / TTS adapters</span>
+            <span>Memory fabric for portable context</span>
+            <span>Voice + GUI reference clients</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Flagship applications</h2>
+        <p class="lead">Demonstrations that showcase sovereign AI in the wild.</p>
+        <div class="grid">
+          <article class="card">
+            <h3>Smart Glasses Agent</h3>
+            <p>
+              Wearable agent that pairs Project Aria’s sensor fidelity with open-source inference, on-device wake words, and
+              privacy controls.
+            </p>
+            <a class="button secondary" href="applications.html#smart-glasses">Learn more</a>
+          </article>
+          <article class="card">
+            <h3>AI for Education</h3>
+            <p>
+              Socratic tutors that schools can deploy locally or on trusted edge servers. Equity, accessibility, and privacy by
+              design.
+            </p>
+            <a class="button secondary" href="applications.html#education">Learn more</a>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Roadmap highlights</h2>
+        <div class="timeline">
+          <div class="timeline-item">
+            <h3>Voice-first agent loop</h3>
+            <p class="lead">Wake-word, ASR, and TTS pipeline optimized for smart glasses and mobile devices.</p>
+          </div>
+          <div class="timeline-item">
+            <h3>Portable memory fabric</h3>
+            <p class="lead">Short-term and long-term context stored under user control with secure sync options.</p>
+          </div>
+          <div class="timeline-item">
+            <h3>Edge deployment toolkit</h3>
+            <p class="lead">Reference deployments for community centers, classrooms, and research labs.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="split">
+          <div>
+            <h2>Join the community</h2>
+            <p class="lead">
+              Project Airos grows with contributions from open-source builders, educators, and device makers. Share feedback,
+              propose features, or help craft new demos.
+            </p>
+            <div class="chip-list">
+              <span class="chip">Open roadmap</span>
+              <span class="chip">Monthly community calls</span>
+              <span class="chip">Research collabs</span>
+            </div>
+          </div>
+          <div class="highlight-box">
+            <p><strong>Ready to build?</strong></p>
+            <p class="lead">Dive into the docs or reach out to collaborate on pilots and research partnerships.</p>
+            <div class="hero-actions">
+              <a class="button" href="community.html">Join community</a>
+              <a class="button secondary" href="mailto:info@projectairos.org">Contact us</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-content">
+        <div>
+          <strong>Project Airos</strong>
+          <p class="quote">Building an open, sovereign AI Agent OS for devices inspired by Meta's Project Aria and beyond.</p>
+        </div>
+        <div class="footer-links">
+          <a href="docs.html">Docs</a>
+          <a href="community.html">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+        </div>
+        <small>© <span id="year"></span> Project Airos. MIT Licensed.</small>
+      </div>
+    </footer>
+    <script src="assets/app.js" defer></script>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/site/tech.html
+++ b/site/tech.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Project Airos Technology</title>
+    <meta
+      name="description"
+      content="Explore the modular architecture behind Project Airos — from MCP orchestration to local-first memory fabric for smart devices."
+    />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="brand" href="index.html">
+          <span class="brand-logo" aria-hidden="true"></span>
+          <span>Project Airos</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+        <div class="nav-links" id="primary-navigation">
+          <a href="about.html">About</a>
+          <a href="tech.html" aria-current="page">Technology</a>
+          <a href="applications.html">Applications</a>
+          <a href="docs.html">Docs</a>
+          <a href="community.html">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="page-hero">
+        <div class="badge">Architecture</div>
+        <h1>The hybrid stack for sovereign agents</h1>
+        <p>
+          Project Airos weaves together open-source components for voice, vision, memory, and orchestration. Deploy on-device,
+          on the edge, or in the cloud with the same blueprint.
+        </p>
+      </section>
+
+      <section class="content-section">
+        <article class="highlight-box">
+          <h2>Core layers</h2>
+          <div class="grid">
+            <div class="card">
+              <h3>Multimodal interface</h3>
+              <p>
+                Reference apps for voice + GUI on phones, PCs, and smart glasses inspired by Meta’s Project Aria sensor suite.
+              </p>
+              <div class="chip-list">
+                <span class="chip">Smart glasses HUD</span>
+                <span class="chip">Desktop console</span>
+                <span class="chip">Mobile app</span>
+              </div>
+            </div>
+            <div class="card">
+              <h3>Agent core</h3>
+              <p>
+                MCP-compliant orchestrator coordinating ASR, TTS, LLM, and tool calls with deterministic routing and guardrails.
+              </p>
+              <div class="chip-list">
+                <span class="chip">Dora runtime</span>
+                <span class="chip">MCP adapters</span>
+                <span class="chip">Skill graph</span>
+              </div>
+            </div>
+            <div class="card">
+              <h3>Memory fabric</h3>
+              <p>
+                Local vector databases synchronize short-term dialogue and long-term knowledge with user-governed retention
+                policies.
+              </p>
+              <div class="chip-list">
+                <span class="chip">SQLite + pgvector</span>
+                <span class="chip">Open embeddings</span>
+                <span class="chip">Encrypted sync</span>
+              </div>
+            </div>
+            <div class="card">
+              <h3>Inference mesh</h3>
+              <p>
+                Plug into vLLM, Qwen, LLaMA, and more. Balance local models with burst-to-cloud options when latency matters.
+              </p>
+              <div class="chip-list">
+                <span class="chip">vLLM</span>
+                <span class="chip">Ollama</span>
+                <span class="chip">Anthropic</span>
+              </div>
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section class="content-section">
+        <div class="split">
+          <div>
+            <h2>Deployment topologies</h2>
+            <p>
+              Choose the footprint that matches your privacy, latency, and cost profile. Airos tooling supports containerized
+              rollouts across hardware tiers.
+            </p>
+            <ul class="list">
+              <li><strong>On-device:</strong> Wearables and mobile hardware with quantized models.</li>
+              <li><strong>Edge cluster:</strong> Micro data centers for schools, offices, and research labs.</li>
+              <li><strong>Hybrid cloud:</strong> Burst to GPUs for heavy workloads, keep context local.</li>
+            </ul>
+          </div>
+          <div class="feature-visual">
+            <span>Profiles for GPU, CPU, and NPU targets</span>
+            <span>Reference Docker Compose stacks</span>
+            <span>Observability via OpenTelemetry</span>
+            <span>Secure key + secret storage guidance</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="content-section">
+        <div>
+          <h2>Extensibility</h2>
+          <p>Design APIs and adapters to encourage experimentation.</p>
+        </div>
+        <div class="grid">
+          <div class="card">
+            <h3>ASR / TTS plugins</h3>
+            <p>Swap Whisper, FunASR, PrimeSpeech, or local DSP stacks using a simple adapter contract.</p>
+          </div>
+          <div class="card">
+            <h3>LLM routers</h3>
+            <p>Route prompts across local, edge, and cloud LLMs with policy-based orchestration and caching.</p>
+          </div>
+          <div class="card">
+            <h3>Toolchains</h3>
+            <p>Expose device sensors, calendars, and third-party APIs through capability-safe tool interfaces.</p>
+          </div>
+          <div class="card">
+            <h3>Memory connectors</h3>
+            <p>Integrate vector stores, graph databases, or even paper notebooks via scanning workflows.</p>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-content">
+        <div>
+          <strong>Project Airos</strong>
+          <p class="quote">Engineering the open stack for sovereign AI on every device.</p>
+        </div>
+        <div class="footer-links">
+          <a href="docs.html">Docs</a>
+          <a href="community.html">Community</a>
+          <a href="blog/index.html">Blog</a>
+          <a href="contact.html">Contact</a>
+        </div>
+        <small>© <span id="year"></span> Project Airos. MIT Licensed.</small>
+      </div>
+    </footer>
+    <script src="assets/app.js" defer></script>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a static HTML/CSS marketing site in the site/ directory covering vision, technology, applications, docs, community, and contact pages
- style the landing experience to echo Meta Project Aria inspiration with reusable navigation, hero, feature cards, and future blog placeholders
- document local preview steps in the README and add deployment guidance for publishing the static site

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68da8689b6648329a1d2eaa0c24e39c8